### PR TITLE
Improve removeInvalidCharacters method. Change subtitles extension to .vtt.

### DIFF
--- a/script.js
+++ b/script.js
@@ -122,24 +122,22 @@ const log = (message, type = "STATUS") =>
 	console.log(`[${APPNAME}]:[${type}]: ${message}`);
 
 
-const replaceQuotesWithSquareBrackets = name =>
-{
-  let isFirstQuote = true;
-  let newName = "";
-  for (let i = 0; i < name.length; i++)
-  {
-  	switch (name[i])
-    {
-    	case '"':
-			newName += isFirstQuote ? '[' : ']';
-			isFirstQuote = !isFirstQuote;
-			break;
-		default:
-			newName += name[i];
+const replaceQuotesWithSquareBrackets = name => {
+	let isFirstQuote = true;
+	let newName = '';
+	for (let i = 0; i < name.length; i++) {
+		switch (name[i]) {
+			case '"':
+				newName += isFirstQuote ? '[' : ']';
+				isFirstQuote = !isFirstQuote;
+				break;
+			default:
+				newName += name[i];
+		}
 	}
-  }
-  return newName.replace('“', '[')
-				.replace('”', ']');
+	newName = newName.replace('“', '[');
+	newName = newName.replace('”', ']');
+	return newName;
 }
 
 const removeInvalidCharacters = name =>

--- a/script.js
+++ b/script.js
@@ -8,7 +8,7 @@ const ROOT_DIRECTORY = 'PluralsightCourseDownloader'
 const INVALID_CHARACTERS = /[\/*?<>|']/g
 const DELIMINATOR = '.'
 const EXTENSION = 'mp4'
-const EXTENSION_SUBS = 'smi'
+const EXTENSION_SUBS = 'vtt'
 
 const qualities = ["1280x720", "1024x768"]
 const DEFAULT_QUALITY = qualities[0]


### PR DESCRIPTION
The removeInvalidCharacters method changes:
1) double quotes are replaced with square brackets.
2) the colon character is replaced with an indented hyphen.
3) old invalid characters replaced with \ / *? <> | ' and are replaced with an empty string.

Subtitles are now saved with the correct .vtt extension.