### PR TITLE
Closes #49

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -198,6 +198,7 @@ const getVideoURL = async videoId => {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
+				'x-team': 'video-services',
 			},
 			body: JSON.stringify({
 				clipId: videoId,


### PR DESCRIPTION
Fixes  #49 

Call to `viewclipURL` now requires an additional HTTP header `x-team` with value `video-services`.